### PR TITLE
Feature inputs highlighting bug 8070

### DIFF
--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -1,10 +1,20 @@
 var Login = {
     
-    initLogin : function() {
+    init : function() {
         Login.positionLogo();
         $(window).resize(function() {
             Login.positionLogo();
         });
+
+        $('#new_local_user').submit(Login.preventEmptyPassword);
+    },
+
+    preventEmptyPassword : function(event) {
+        var password = $('#local_user_password');
+        if(password.val().length == 0) {
+            event.preventDefault();
+            password.focus();
+        }
     },
 
     positionLogo : function() {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -5,7 +5,7 @@ var ready = (function () {
     $(window).off('scroll');
 
     if ($('#body-sessions-new').length) {
-        Login.initLogin();
+        Login.init();
     }
 
     if ($('#body-weeks-show').length) {

--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -33,6 +33,7 @@
   @include login-input;
   width: 70%;
   max-width: 300px;
+  background-color: $dark;
 }
 
 .login-remember-me {

--- a/app/assets/stylesheets/setup/reset.scss
+++ b/app/assets/stylesheets/setup/reset.scss
@@ -107,7 +107,8 @@ a {
 a:active,
 a:hover,
 input,
-select {
+select,
+textarea {
   outline: 0;
 }
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -8,10 +8,10 @@
         <label>Prihláste sa AIS údajmi.</label>
 
         <%= f.label :login, "Prihlasovacie meno" %>
-        <%= f.text_field :login, autofocus: true, class: "login-text" %>
+        <%= f.text_field :login, autofocus: true, class: "login-text", tabindex: 1 %>
 
         <%= f.label :password, "Heslo" %>
-        <%= f.password_field :password, autocomplete: "off", class: "login-text" %>
+        <%= f.password_field :password, autocomplete: "off", class: "login-text", tabindex: 2 %>
 
         <% if devise_mapping.rememberable? -%>
             <%= f.label :remember_me, class: "login-remember-me" do %>


### PR DESCRIPTION
Uz by to malo prestat zvyraznovat, aj ked by sa na to mohlo otestovat.

Este som pridal drobnu zmenu, ze sa neodosiela formular ak je prazdne heslo. Na mobiloch je bezne tlacidlo Go, ktore ked pouzivatel stlaci ked je v inpute meno, tak ho to presmeruje na input heslo.